### PR TITLE
Split models.py into multiple files & directories

### DIFF
--- a/fancypages/models/__init__.py
+++ b/fancypages/models/__init__.py
@@ -1,0 +1,3 @@
+from fancypages.models.base import *
+from fancypages.models.containers import *
+from fancypages.models.widgets import *

--- a/fancypages/models/containers.py
+++ b/fancypages/models/containers.py
@@ -1,0 +1,17 @@
+from django.db import models
+
+from fancypages.models.base import Container
+
+
+class OrderedContainer(Container):
+    display_order = models.PositiveIntegerField()
+
+    def __unicode__(self):
+        return u"Container #%d '%s' in '%s'" % (
+            self.display_order,
+            self.variable_name,
+            self.content_type
+        )
+
+    class Meta:
+        app_label = 'fancypages'

--- a/fancypages/models/widgets/__init__.py
+++ b/fancypages/models/widgets/__init__.py
@@ -1,0 +1,18 @@
+from fancypages.models.widgets.layouts import (
+    TabWidget,
+    TwoColumnLayoutWidget,
+    ThreeColumnLayoutWidget,
+    FourColumnLayoutWidget,
+)
+from fancypages.models.widgets.content import (
+    TextWidget,
+    TitleTextWidget,
+    ImageWidget,
+)
+from fancypages.models.widgets.product import (
+    SingleProductWidget,
+    HandPickedProductsPromotionWidget,
+    AutomaticProductsPromotionWidget,
+    OfferWidget,
+)
+from fancypages.models.widgets.social import (VideoWidget, TwitterWidget)

--- a/fancypages/models/widgets/content.py
+++ b/fancypages/models/widgets/content.py
@@ -1,0 +1,73 @@
+import os
+
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from fancypages.models.base import Widget, ImageMetadataMixin
+
+
+class TextWidget(Widget):
+    name = _("Text")
+    code = 'text'
+    template_name = "fancypages/widgets/textwidget.html"
+
+    text = models.TextField(_("Text"), default="Your text goes here.")
+
+    def __unicode__(self):
+        return self.text[:20]
+
+    class Meta:
+        app_label = 'fancypages'
+
+
+class TitleTextWidget(Widget):
+    name = _("Title and text")
+    code = 'title-text'
+    template_name = "fancypages/widgets/titletextwidget.html"
+
+    title = models.CharField(_("Title"), max_length=100,
+                             default="Your title goes here.")
+    text = models.TextField(_("Text"), default="Your text goes here.")
+
+    def __unicode__(self):
+        return self.title
+
+    class Meta:
+        app_label = 'fancypages'
+
+
+class ImageWidget(Widget, ImageMetadataMixin):
+    name = _("Image")
+    code = 'image'
+    template_name = "fancypages/widgets/imagewidget.html"
+
+    image_asset = models.ForeignKey('assets.ImageAsset', verbose_name=_("Image asset"),
+                                    related_name="image_widgets", blank=True, null=True)
+
+    def __unicode__(self):
+        if self.image_asset:
+            return u"Image '%s'" % os.path.basename(self.image_asset.image.path)
+        return u"Image #%s" % self.id
+
+    class Meta:
+        app_label = 'fancypages'
+
+
+class ImageAndTextWidget(Widget, ImageMetadataMixin):
+    name = _("Image and text")
+    code = 'image-text'
+    template_name = "fancypages/widgets/imageandtextwidget.html"
+
+    image_asset = models.ForeignKey('assets.ImageAsset', verbose_name=_("Image asset"),
+                                    related_name="image_text_widgets", blank=True, null=True)
+
+    text = models.CharField(_("Text"), max_length=2000,
+                                   default="Your text goes here.")
+
+    def __unicode__(self):
+        if self.image_asset:
+            return u"Image with text '%s'" % os.path.basename(self.image_asset.image.path)
+        return u"Image with text #%s" % self.id
+
+    class Meta:
+        app_label = 'fancypages'

--- a/fancypages/models/widgets/layouts.py
+++ b/fancypages/models/widgets/layouts.py
@@ -1,0 +1,65 @@
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+from django.contrib.contenttypes.generic import GenericRelation
+
+from fancypages.models.base import Widget, LayoutWidget
+from fancypages.models.containers import OrderedContainer
+
+
+class TabWidget(Widget):
+    name = _("Tabbed block")
+    code = 'tabbed-block'
+    context_object_name = "widget"
+    template_name = "fancypages/widgets/tabbedblockwidget.html"
+
+    tabs = GenericRelation('fancypages.OrderedContainer')
+
+    def save(self, *args, **kwargs):
+        super(TabWidget, self).save(*args, **kwargs)
+        if not self.tabs.count():
+            OrderedContainer.objects.create(page_object=self, display_order=0,
+                                            title=_("New Tab"))
+
+    class Meta:
+        app_label = 'fancypages'
+
+
+class TwoColumnLayoutWidget(LayoutWidget):
+    name = _("Two column layout")
+    code = 'two-column-layout'
+    template_name = "fancypages/widgets/two_column_layout.html"
+
+    LEFT_WIDTH_CHOICES = [(x, x) for x in range(1, 12)]
+    left_width = models.PositiveIntegerField(_("Left Width"), max_length=3,
+                                             choices=LEFT_WIDTH_CHOICES, default=6)
+
+    @property
+    def left_span(self):
+        """ Returns the bootstrap span class for the left container. """
+        return u'span%d' % self.left_width
+
+    @property
+    def right_span(self):
+        """ Returns the bootstrap span class for the left container. """
+        return u'span%d' % (self.BOOTSTRAP_MAX_WIDTH - self.left_width)
+
+    class Meta:
+        app_label = 'fancypages'
+
+
+class ThreeColumnLayoutWidget(LayoutWidget):
+    name = _("Three column layout")
+    code = 'three-column-layout'
+    template_name = "fancypages/widgets/three_column_layout.html"
+
+    class Meta:
+        app_label = 'fancypages'
+
+
+class FourColumnLayoutWidget(LayoutWidget):
+    name = _("Four column layout")
+    code = 'four-column-layout'
+    template_name = "fancypages/widgets/four_column_layout.html"
+
+    class Meta:
+        app_label = 'fancypages'

--- a/fancypages/models/widgets/product.py
+++ b/fancypages/models/widgets/product.py
@@ -1,0 +1,85 @@
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from fancypages.models.base import Widget
+
+Product = models.get_model('catalogue', 'Product')
+
+
+class SingleProductWidget(Widget):
+    name = _("Single Product")
+    code = 'single-product'
+    template_name = "fancypages/widgets/productwidget.html"
+
+    product = models.ForeignKey(
+        'catalogue.Product',
+        verbose_name=_("Single Product"), null=True, blank=False)
+
+    def __unicode__(self):
+        if self.product:
+            return u"Product '%s'" % self.product.upc
+        return u"Product '%s'" % self.id
+
+    class Meta:
+        app_label = 'fancypages'
+
+
+class HandPickedProductsPromotionWidget(Widget):
+    name = _("Hand Picked Products Promotion")
+    code = 'promotion-hand-picked-products'
+    template_name = "fancypages/widgets/promotionwidget.html"
+
+    promotion = models.ForeignKey(
+        'promotions.HandPickedProductList',
+        verbose_name=_("Hand Picked Products Promotion"), null=True, blank=False)
+
+    def __unicode__(self):
+        if self.promotion:
+            return u"Promotion '%s'" % self.promotion.pk
+        return u"Promotion '%s'" % self.id
+
+    class Meta:
+        app_label = 'fancypages'
+
+
+class AutomaticProductsPromotionWidget(Widget):
+    name = _("Automatic Products Promotion")
+    code = 'promotion-ordered-products'
+    template_name = "fancypages/widgets/promotionwidget.html"
+
+    promotion = models.ForeignKey(
+        'promotions.AutomaticProductList',
+        verbose_name=_("Automatic Products Promotion"), null=True, blank=False)
+
+    def __unicode__(self):
+        if self.promotion:
+            return u"Promotion '%s'" % self.promotion.pk
+        return u"Promotion '%s'" % self.id
+
+    class Meta:
+        app_label = 'fancypages'
+
+
+class OfferWidget(Widget):
+    name = _("Offer Products")
+    code = 'products-range'
+    template_name = "fancypages/widgets/offerwidget.html"
+
+    offer = models.ForeignKey(
+        'offer.ConditionalOffer',
+        verbose_name=_("Offer"), null=True, blank=False)
+
+    @property
+    def products(self):
+        range = self.offer.condition.range
+        if range.includes_all_products:
+            return Product.browsable.filter(is_discountable=True)
+        return range.included_products.filter(is_discountable=True)
+
+    def __unicode__(self):
+        if self.offer:
+            return u"Offer '%s'" % self.offer.pk
+        return u"Offer '%s'" % self.id
+
+    class Meta:
+        app_label = 'fancypages'

--- a/fancypages/models/widgets/social.py
+++ b/fancypages/models/widgets/social.py
@@ -1,0 +1,43 @@
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from fancypages.models.base import Widget
+
+
+class VideoWidget(Widget):
+    name = _("Video")
+    code = 'video'
+    template_name = "fancypages/widgets/video.html"
+
+    SOURCE_YOUTUBE = 'youtube'
+    SOURCES = (
+        (SOURCE_YOUTUBE, _('YouTube video')),
+    )
+
+    source = models.CharField(_('Video Type'), choices=SOURCES, max_length=50)
+    video_code = models.CharField(_('Video Code'), max_length=50)
+
+    def __unicode__(self):
+        if self.source:
+            return "Video '%s'" % self.video_code
+        return "Video #%s" % self.id
+
+    class Meta:
+        app_label = 'fancypages'
+
+
+class TwitterWidget(Widget):
+    name = _("Twitter")
+    code = 'twitter'
+    template_name = "fancypages/widgets/twitter.html"
+
+    username = models.CharField(_('Twitter username'), max_length=50)
+    max_tweets = models.PositiveIntegerField(_('Maximum tweets'), default=5)
+
+    def __unicode__(self):
+        if self.username:
+            return u"Twitter user '@%s'" % self.username
+        return u"Twitter: %s" % self.id
+
+    class Meta:
+        app_label = 'fancypages'


### PR DESCRIPTION
Splitting model definitions into several sub directories to make them easier to find. The change is backwards compatible as all models can be imported from `fancypages.models`.
