### PR TITLE
Experimental/oscar 0.4 support less fix

### DIFF
--- a/fancypages/static/fancypages/less/bootstrap/mixins.less
+++ b/fancypages/static/fancypages/less/bootstrap/mixins.less
@@ -247,6 +247,7 @@
   .border-bottom-left-radius(@radius);
 }
 
+
 // Drop shadows
 .box-shadow(@shadowA, @shadowB:X, ...){
   // Multiple shadow solution from http://toekneestuck.com/blog/2012/05/15/less-css-arguments-variable/
@@ -558,13 +559,13 @@
   .core (@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~".span@{index}") { .span(@index); }
+      .span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~".offset@{index}") { .offset(@index); }
+      .offset@{index} { .offset(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}
@@ -603,14 +604,14 @@
   .fluid (@fluidGridColumnWidth, @fluidGridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~".span@{index}") { .span(@index); }
+      .span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~'.offset@{index}') { .offset(@index); }
-      (~'.offset@{index}:first-child') { .offsetFirstChild(@index); }
+      .offset@{index} { .offset(@index); }
+      .offset@{index}:first-child { .offsetFirstChild(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}
@@ -653,7 +654,7 @@
   .input(@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~"input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index}") { .span(@index); }
+      input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}


### PR DESCRIPTION
LESS 1.4.1 no longer supports the syntax for variables in loops being escaped (~"like this") but instead they should have no surrounding bits, like this.

Note that this change will break the compiling of this LESS in versions below 1.4.1.
